### PR TITLE
Changed EPSILON to set std to +/-EPSILON rather than 0.0

### DIFF
--- a/PeakDetection.cpp
+++ b/PeakDetection.cpp
@@ -72,7 +72,16 @@ void PeakDetection::begin(int lag, int threshold, double influence) {
   }
 }
 
-void PeakDetection::add(double newSample) {
+void PeakDetection::setEpsilon(double epsilon) {
+  this->EPSILON = epsilon;
+}
+
+double PeakDetection::getEpsilon() {
+  return(EPSILON);
+}
+
+//void PeakDetection::add(double newSample) {
+double PeakDetection::add(double newSample) {
   peak = 0;
   int i = index % lag; //current index
   int j = (index + 1) % lag; //next index
@@ -92,6 +101,7 @@ void PeakDetection::add(double newSample) {
   index++;
   if (index >= 16383) //2^14
     index = lag + j;
+  return(std[j]);
 }
 
 double PeakDetection::getFilt() {
@@ -123,7 +133,10 @@ double PeakDetection::getStd(int start, int len) {
   double powx1 = x1 * x1;
   double std = x2 - powx1;
   if (std > -EPSILON && std < EPSILON)
-    return 0.0;
+    if(std < 0.0)
+        return(-EPSILON);
+    else
+        return(EPSILON);
   else
     return sqrt(x2 - powx1);
 }

--- a/PeakDetection.h
+++ b/PeakDetection.h
@@ -36,9 +36,12 @@ class PeakDetection {
     ~PeakDetection();
     void begin();
     void begin(int, int, double); //lag, threshold, influence
-    void add(double);
+    //void add(double);
+    double add(double);
     double getFilt();
     int getPeak();
+    void setEpsilon(double);
+    double getEpsilon();
 
   private:
     int index, lag, threshold, peak;


### PR DESCRIPTION
Added functions to set/get EPSILON. Also, as written, if -EPSILON < std < +EPSILON, std was set to 0.0. This made the peak trigger off of noise once the system settled into a steady state rather than actual signals. I changed the algorithm to return -EPSILON if -EPSILON < std < 0.0 and +EPSILON if 0.0 <= std < EPSILON.